### PR TITLE
Fix tmpDir for gacco enviroment

### DIFF
--- a/diff-detector.go
+++ b/diff-detector.go
@@ -71,7 +71,7 @@ func _main() (st int) {
 		fmt.Printf("%s", err)
 		return
 	}
-	tmpDir := os.TempDir();
+	tmpDir := "/edx/var/mackerel/diff-detector"
 
 	hasher := md5.New()
 	hasher.Write([]byte(opts.OptIdentifier))


### PR DESCRIPTION
diff-detectorの引数で渡したコマンドの実行結果を格納するtmpDirをgacco環境用（Mackerel配下で実行する環境用）に修正。
